### PR TITLE
Add Python 3.6 requirement to Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,5 +13,9 @@ flask-migrate = "*"
 "psycopg2" = "*"
 
 
-[dev-packages]
+[requires]
 
+python_version = "3.6"
+
+
+[dev-packages]


### PR DESCRIPTION
This was something I had to adjust when setting up on my system.